### PR TITLE
Set write_bytes legend to "bytes written"

### DIFF
--- a/Spark_Dashboard/Spark_Perf_Dashboard_v01.json
+++ b/Spark_Dashboard/Spark_Perf_Dashboard_v01.json
@@ -3506,7 +3506,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "hdfs bytes read - Executor $tag_process",
+          "alias": "hdfs bytes written - Executor $tag_process",
           "groupBy": [
             {
               "params": [

--- a/Spark_Dashboard/Spark_Perf_Dashboard_v01_with_annotations.json
+++ b/Spark_Dashboard/Spark_Perf_Dashboard_v01_with_annotations.json
@@ -3604,7 +3604,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "hdfs bytes read - Executor $tag_process",
+          "alias": "hdfs bytes written - Executor $tag_process",
           "groupBy": [
             {
               "params": [

--- a/Spark_Dashboard/Spark_Perf_Dashboard_v03.json
+++ b/Spark_Dashboard/Spark_Perf_Dashboard_v03.json
@@ -5313,7 +5313,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "hdfs bytes read - Executor $tag_process",
+          "alias": "hdfs bytes written - Executor $tag_process",
           "groupBy": [
             {
               "params": [

--- a/Spark_Dashboard/Spark_Perf_Dashboard_v03_with_SparkPlugins.json
+++ b/Spark_Dashboard/Spark_Perf_Dashboard_v03_with_SparkPlugins.json
@@ -7983,7 +7983,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "hdfs bytes read - Executor $tag_process",
+          "alias": "hdfs bytes written - Executor $tag_process",
           "groupBy": [
             {
               "params": [

--- a/Spark_Dashboard/Spark_Perf_Dashboard_v03_with_SparkPlugins_Experimental.json
+++ b/Spark_Dashboard/Spark_Perf_Dashboard_v03_with_SparkPlugins_Experimental.json
@@ -10605,7 +10605,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "hdfs bytes read - Executor $tag_process",
+          "alias": "hdfs bytes written - Executor $tag_process",
           "groupBy": [
             {
               "params": [

--- a/Spark_Dashboard/Spark_Perf_Dashboard_v03_with_annotations.json
+++ b/Spark_Dashboard/Spark_Perf_Dashboard_v03_with_annotations.json
@@ -5349,7 +5349,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "hdfs bytes read - Executor $tag_process",
+          "alias": "hdfs bytes written - Executor $tag_process",
           "groupBy": [
             {
               "params": [


### PR DESCRIPTION
I noticed when auditing our prometheus-version of our 03 dashboard that the legend text for `filesystem.hdfs.write_bytes` said "read" which seemed incorrect.

I think this should fix it up.